### PR TITLE
ci: GHA workflow security cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
         go-version: ['1.21', '1.22', '1.23']
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         persist-credentials: false
 
     - name: Set up Go ${{ matrix.go-version }}
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: ${{ matrix.go-version }}
         
@@ -40,7 +40,7 @@ jobs:
       
     - name: Upload coverage to Codecov
       if: matrix.go-version == '1.21' && success()
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
       with:
         file: ./coverage.txt
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -53,17 +53,17 @@ jobs:
       contents: read
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         persist-credentials: false
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '1.21'
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3
       with:
         version: latest
         args: --timeout=5m
@@ -75,12 +75,12 @@ jobs:
       contents: read
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         persist-credentials: false
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version: '1.21'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-      
+      with:
+        persist-credentials: false
+
     - name: Set up Go ${{ matrix.go-version }}
       uses: actions/setup-go@v5
       with:
@@ -45,12 +47,14 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-      
+      with:
+        persist-credentials: false
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: '1.21'
-        
+
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
@@ -63,12 +67,14 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-      
+      with:
+        persist-credentials: false
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: '1.21'
-        
+
     - name: Build
       run: go build -v ./cmd/echo-server
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,15 @@ on:
       - '*'
   pull_request:
     types: [opened, synchronize, reopened]
+
+permissions: {}
+
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         go-version: ['1.21', '1.22', '1.23']
@@ -44,6 +49,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -64,6 +71,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -14,12 +14,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.21'
 
@@ -37,12 +37,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.21'
 
@@ -54,7 +54,7 @@ jobs:
           CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -ldflags '-extldflags "-static"' -o artifacts/build/release/linux/arm64/echo-server ./cmd/echo-server
           
       - name: Set up Fly command-line tool
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # master
         
       - name: Deploy to Fly
         run: flyctl deploy --remote-only

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -10,12 +10,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+        with:
+          persist-credentials: false
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.21'
-          
+
       - name: Get dependencies
         run: go mod download
         
@@ -29,12 +31,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+        with:
+          persist-credentials: false
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version: '1.21'
-          
+
       - name: Build for deployment
         run: |
           mkdir -p artifacts/build/release/linux/amd64

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -3,10 +3,15 @@ on:
   push:
     branches:
       - main
+
+permissions: {}
+
 jobs:
   test:
     name: Test before deploy
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,6 +33,8 @@ jobs:
     name: Deploy app
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Routine hygiene pass over the GitHub Actions workflows in this repo, addressing findings from a workflow security audit. Changes are split into three commits, one per finding type:

  - Disable credential persistence on actions/checkout steps so the default GITHUB_TOKEN is not left in the local git config after checkout.
  - Scope each job's permissions explicitly: top-level permissions: {}, with each job granted only the GITHUB_TOKEN scopes it actually needs (contents: read).
  - Pin all actions to commit SHAs (with the original tag/branch preserved as a comment) so an upstream tag move can't silently change what runs in CI.

  No behavioural changes intended — the workflows run the same checks against the same inputs.